### PR TITLE
"More Tips" link in the header of the "Tip of the Day" block!

### DIFF
--- a/themes/btaTheme/layouts/index.html
+++ b/themes/btaTheme/layouts/index.html
@@ -5,7 +5,7 @@
         </div>
         <div class="col-lg-4">
             {{- partial "latest-homepage.html" -}}
-            <h2 class="mt-0 pb-1">What's happening?</h2>
+            <h2 class="pb-1">What's happening?</h2>
             <div>
                 {{ range ( where .Site.RegularPages "Type" "article" | first 3 ) }}
                     <div class="d-flex mb-2">

--- a/themes/btaTheme/layouts/index.html
+++ b/themes/btaTheme/layouts/index.html
@@ -27,7 +27,10 @@
                 {{ end }}
             </div>
             <hr />
-            <h2 class="pb-1">Tip of the Day!</h2>
+			<div class="pb-1 mt-5 mb-2 d-flex align-items-center justify-content-between">
+				<h2 class="m-0">Tip of the Day!</h2>
+				<a href="/tutorials/">More Tips</a>
+			</div>
             <div>
                 <video
                     id="thaboar-video"

--- a/themes/btaTheme/layouts/index.html
+++ b/themes/btaTheme/layouts/index.html
@@ -5,6 +5,7 @@
         </div>
         <div class="col-lg-4">
             {{- partial "latest-homepage.html" -}}
+			<hr />
             <h2 class="pb-1">What's happening?</h2>
             <div>
                 {{ range ( where .Site.RegularPages "Type" "article" | first 3 ) }}

--- a/themes/btaTheme/layouts/partials/latest-homepage.html
+++ b/themes/btaTheme/layouts/partials/latest-homepage.html
@@ -46,7 +46,6 @@
                     </a>
                 </div>
             </div>
-            <hr />
         {{ end }}
     {{ end }}
 {{ end }}

--- a/themes/btaTheme/layouts/partials/latest-homepage.html
+++ b/themes/btaTheme/layouts/partials/latest-homepage.html
@@ -46,7 +46,7 @@
                     </a>
                 </div>
             </div>
-            <hr class="mb-5" />
+            <hr />
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
Changes:
- Added "more tips" *(can be renamed to a better name)* link in the header of the "tip of the day" block
- Changed layout of "latest release" and "what's happening" blocks, so layout become more flexible
  For example now you can put "latest release" block in any place without `<hr>` element in bottom of this block

These are small changes, but they improve the UX in some way :)